### PR TITLE
Fix inf in standard_normal

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,0 +1,15 @@
+Changelog
+=========
+
+0.1.1 (2021-12-18)
+------------------
+
+Fixes
+~~~~~
+- ``standard_normal`` sometimes produces ``inf`` [#1]
+
+
+0.1 (2021-12-06)
+----------------
+
+- Initial release

--- a/README.md
+++ b/README.md
@@ -17,13 +17,13 @@ seed = 123
 parallel_rng = parallel_numpy_rng.default_rng(seed)
 numpy_rng = np.random.default_rng(seed)
 
-%timeit numpy_rng.random(size=10**9, dtype=np.float32)                           # 2.89 s
-%timeit parallel_rng.random(size=10**9, dtype=np.float32, nthread=1)             # 3.35 s
-%timeit parallel_rng.random(size=10**9, dtype=np.float32, nthread=128)           # 73.9 ms
+%timeit numpy_rng.random(size=10**9, dtype=np.float32)                           # 2.85 s
+%timeit parallel_rng.random(size=10**9, dtype=np.float32, nthread=1)             # 3.34 s
+%timeit parallel_rng.random(size=10**9, dtype=np.float32, nthread=128)           # 67.8 ms
 
-%timeit numpy_rng.standard_normal(size=10**8, dtype=np.float32)                  # 1.13 s
-%timeit parallel_rng.standard_normal(size=10**8,dtype=np.float32, nthread=1)     # 1.87 s
-%timeit parallel_rng.standard_normal(size=10**8, dtype=np.float32, nthread=128)  # 36.6 ms
+%timeit numpy_rng.standard_normal(size=10**8, dtype=np.float32)                  # 1.12 s
+%timeit parallel_rng.standard_normal(size=10**8,dtype=np.float32, nthread=1)     # 1.85 s
+%timeit parallel_rng.standard_normal(size=10**8, dtype=np.float32, nthread=128)  # 43.5 ms
 ```
 
 Note that the `parallel_rng` is slower than Numpy when using a single thread, because the parallel implementation requires a slower algorithm in some cases (this is especially noticeable for float64 and normals)

--- a/test_parallel_numpy_rng.py
+++ b/test_parallel_numpy_rng.py
@@ -135,3 +135,21 @@ def test_uniform_matches_numpy(someN, seed, nthread, dtype):
             assert np.allclose(a, b, atol=1e-7)
         else:
             raise ValueError(dtype)
+
+
+def test_finite_normals_float32():
+    '''
+    If the floats fed to Box-Muller can include 0, it will produce infinity.
+    We use the interval (0,1] to avoid this.
+    
+    In theory, we ought to test float64 the same way. But it's hard to find
+    a PCG state that produces 53 zeros...
+    
+    https://github.com/lgarrison/parallel-numpy-rng/issues/1
+    '''
+    from parallel_numpy_rng import MTGenerator
+    pcg = np.random.PCG64(1194)
+    mtg = MTGenerator(pcg)
+    a = mtg.standard_normal(size=20000, nthread=maxthreads, dtype=np.float32)
+    assert np.all(np.isfinite(a))
+    


### PR DESCRIPTION
From #1, Box-Muller was using uniform floats in the half-open interval [0,1), which would cause it to generate an `inf` if it encountered 0 exactly.  We now instead generate uniform floats in (0,1] (just for BM; uniform randoms are unchanged).  This will cause the `standard_normal` results to change in the last few digits from what they were before.

The Box-Muller Wikipedia article says the uniform floats should be in the open interval (0,1), but this is hard to do without rejection sampling... if we are making an error, it's at most O(2^-24) for floats and less for doubles.